### PR TITLE
Gulp-jscs does not close the stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ module.exports = function (config) {
 	}, function (cb) {
 		if (out.length > 0) {
 			this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n\n')));
+		} else {
+			this.push(null);
 		}
 
 		cb();


### PR DESCRIPTION
Closing the stream when we're done allows other tools to know
when gulp-jscs is finished working.
