### PR TITLE
Try/Catch jscs errors and emit them

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,13 +22,19 @@ module.exports = function (config) {
 			return cb();
 		}
 
-		var errors = checker.checkString(file.contents.toString(), path.basename(file.path));
+		try {
+			var errors = checker.checkString(file.contents.toString(), path.basename(file.path));
 
-		errors.getErrorList().forEach(function (err) {
-			out.push(errors.explainError(err, true));
-		});
+			errors.getErrorList().forEach(function (err) {
+				out.push(errors.explainError(err, true));
+			});
 
-		this.push(file);
+			this.push(file);
+		} catch (err) {
+			this.emit('error', new gutil.PluginError('gulp-jscs', err));
+			return cb();
+		}
+		
 		cb();
 	}, function (cb) {
 		if (out.length > 0) {


### PR DESCRIPTION
wrap .checkString in a try/catch.  In the case where jscs throws an exception due to a hard error, it ought to be emitted as an error.  To be caught by stream.on('error', ...
