### PR TITLE
Running gulp-jscs on a glob of files by pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ module.exports = function (options) {
 			out.push(err.message.replace('null:', file.relative + ':'));
 		}
 
-		this.push(file);
 		cb();
 	}, function (cb) {
 		if (out.length > 0) {


### PR DESCRIPTION
Heya,

When trying to throw in a glob of files the output is not shown.

``` js
gulp.task('jscs', function () {
    return gulp.src('./src/common/**/*.js')
        .pipe(jscs('./.jscsrc'));
});
```

Without the this.push(file). The functionality for a single file will still work.

But it will also output the error messages for multiple files and arrays of files

``` js
return gulp.src([ 'file1.js',  'file2.js' ])
        .pipe(jscs('./.jscsrc'));
//and
    return gulp.src('./src/common/**/*.js')
        .pipe(jscs('./.jscsrc'));
```

Note: I'm not sure why the `this.push(file)` line was there. But it seems like it doesn't change the functionality without it.
