### PR TITLE
Support custom reporters (and reporters from jscs)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,44 @@ var through = require('through2');
 var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');
 
-module.exports = function (options) {
+var fs = require('fs');
+var path = require('path');
+
+function stockReporter (errorCollection) {
 	var out = [];
+	errorCollection.forEach(function (errors) {
+		errors.getErrorList().forEach(function (err) {
+			out.push(errors.explainError(err, true) + '\n');
+		});
+	});
+
+	this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n'), {
+		showStack: false
+	}));
+}
+
+function getReporter (reporter) {
+	if (typeof reporter === 'string') {
+		var reporterPath = path.resolve(process.cwd(), reporter);
+
+		if (!fs.existsSync(reporterPath)) {
+			reporterPath = 'jscs/lib/reporters/' + reporter;
+		}
+		try {
+			return require(reporterPath);
+		} catch (e) {
+			console.error('Reporter "%s" doesn\'t exist.', reporterPath);
+			return;
+		}
+	}
+
+	return typeof reporter === 'function' ?
+			reporter :
+			stockReporter;
+}
+
+module.exports = function (options, reporter) {
+	var errorCollection = [];
 	var checker = new Checker({esnext: options && !!options.esnext});
 
 	checker.registerDefaultRules();
@@ -35,21 +71,18 @@ module.exports = function (options) {
 
 		try {
 			var errors = checker.checkString(file.contents.toString(), file.relative);
-			errors.getErrorList().forEach(function (err) {
-				out.push(errors.explainError(err, true));
-			});
+			if (errors.getErrorCount() > 0) {
+				errors.filePath = file.path;
+				errorCollection.push(errors);
+			}
 		} catch (err) {
-			out.push(err.message.replace('null:', file.relative + ':'));
+			console.error(err.message.replace('null:', file.relative + ':'));
 		}
 
 		cb(null, file);
 	}, function (cb) {
-		if (out.length > 0) {
-			this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n\n'), {
-				showStack: false
-			}));
-		}
+		getReporter(reporter).call(this, errorCollection);
 
 		cb();
 	});
-};
+}; 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,11 @@ function stockReporter (errorCollection) {
 		});
 	});
 
-	this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n'), {
-		showStack: false
-	}));
+	if (out.length > 0) {
+		this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n'), {
+			showStack: false
+		}));
+	}
 }
 
 function getReporter (reporter) {
@@ -85,4 +87,4 @@ module.exports = function (options, reporter) {
 
 		cb();
 	});
-}; 
+};


### PR DESCRIPTION
My English is very bad, so I will explain by code

This pull request add ability to define custom reporters in those manners:

### Reporter from custom file (own reporter)
```javascript
gulp.task('jscs:storm', function() {
  var jscs = require('gulp-jscs');
  var config = {...};
  return gulp.src(...)
    .pipe(jscs(config, 'myReporter.js'));
});
```

### Standart reporter (from jscs: `text, junit, inlinesingle, inline, console, checkstyle`)
```javascript
gulp.task('jscs:storm', function() {
  var jscs = require('gulp-jscs');
  var config = {...};
  return gulp.src(...)
    .pipe(jscs(config, 'checkstyle'));
});
```

### Custom function for reporter
```javascript
function myReporter (errorCollection) {
  errorCollection.forEach(function(errors) {
    errors.getErrorList().forEach(function(err) {
      console.log(errors.filePath + ':' + err.line + ' (col ' + err.column + '), ' + err.message);
    });
  });
}

gulp.task('jscs:storm', function() {
  var jscs = require('gulp-jscs');
  var config = {...};
  return gulp.src(...)
    .pipe(jscs(config, myReporter));
});
```
The reporter above useful for run gulp task in webstorm. Supports quick navigation from console by clicking on filename.

### Without reporter works as usual
```javascript
gulp.task('jscs:storm', function() {
  var jscs = require('gulp-jscs');
  var config = {...};
  return gulp.src(...)
    .pipe(jscs(config));
});
```

_Also added field `filePath` to every item in `errorCollection` for getting absolute path of file._
