### PR TITLE
updating exported function to allow passed options for the through.obj call

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var through = require('through2');
 var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');
 
-module.exports = function (options) {
+module.exports = function (options, throughOptions) {
 	var out = [];
 	var checker = new Checker({esnext: options && !!options.esnext});
 
@@ -17,7 +17,8 @@ module.exports = function (options) {
 		checker.configure(loadConfigFile.load(options));
 	}
 
-	return through.obj(function (file, enc, cb) {
+	return through.obj(throughOptions,
+    function (file, enc, cb) {
 		if (file.isNull()) {
 			cb(null, file);
 			return;


### PR DESCRIPTION
This is a fix related to issue https://github.com/jscs-dev/gulp-jscs/issues/42

So I found that in through2, it sets a default value for `highWaterMark` to 16, which was limiting the jscs checking when the source provided exceed 16 files (and ended up preventing it from reporting any errors regardless of what files were checked). You can override that by passing it as an option to the through.obj call, but there was no exposed way to pass options to that call. I'm not sure if this is the best way to expose that configuration, but this is how I was able to solve that problem. Let me know if you think it looks like a viable solution!
