### PR TITLE
Do not mutate the options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');
+var assign = require('object-assign');
 
 module.exports = function (options) {
 	var out = [];
@@ -11,6 +12,7 @@ module.exports = function (options) {
 	checker.registerDefaultRules();
 
 	if (typeof options === 'object') {
+		options = assign({}, options);
 		delete options.esnext;
 		checker.configure(options);
 	} else {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "jscs": "^1.5.9",
+    "object-assign": "^1.0.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -86,3 +86,8 @@ it('should respect "excludeFiles" from config', function (cb) {
 	stream.end();
 });
 
+it('should not mutate the options object passed as argument', function () {
+	var options = {esnext: true};
+	jscs(options);
+	assert.equal(options.esnext, true);
+});


### PR DESCRIPTION
Avoid mutating the options object as:
1. Consumers may reuse the given object elsewhere in their code;
2. [lazypipe](https://github.com/OverZealous/lazypipe) expects immutable arguments, it will throw an error when used with gulp-jscs at the moment.
