### PR TITLE
Renames `checker._isExcluded` method to new name

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (options) {
 			return;
 		}
 
-		if (checker._isExcluded(file.path)) {
+		if (checker.getConfiguration().isFileExcluded(file.path)) {
 			cb(null, file);
 			return;
 		}


### PR DESCRIPTION
Fixes #53
