### PR TITLE
Attach jscs errors to the file object, like gulp-jshint.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,14 @@ module.exports = function (options) {
 
 		try {
 			var errors = checker.checkString(file.contents.toString(), file.relative);
-			errors.getErrorList().forEach(function (err) {
+			var errorList = errors.getErrorList();
+			file.jscs = {success: true, errorCount: 0, errors: []};
+			if (errorList.length > 0) {
+				file.jscs.success = false;
+				file.jscs.errorCount = errorList.length;
+				file.jscs.errors = errorList;
+			}
+			errorList.forEach(function (err) {
 				out.push(errors.explainError(err, true));
 			});
 		} catch (err) {

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,22 @@ gulp.task('default', function () {
 ```
 
 
+## Results
+
+A `jscs` object will be attached to the file object which can be used for custom error reporting. An example with one error might look like this:
+
+```js
+{ success: false,  // or true if no errors
+  errorCount: 1,   // number of errors in the errors array
+  errors: [        // an array of jscs error objects
+    { filename: 'index.js',  // basename of the file
+      rule: 'requireCamelCaseOrUpperCaseIdentifiers',  // jscs rule which triggered the error
+      message: 'All identifiers must be camelCase or UPPER_CASE',  // error message returned by the rule
+      line: 32,    // error line number
+      column: 7 }  // error column
+  ]};
+```
+
 ## API
 
 ### jscs(options)

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var gutil = require('gulp-util');
 var jscs = require('./');
 
 it('should check code style of JS files', function (cb) {
+	this.timeout(5000);
 	var stream = jscs();
 
 	stream.on('error', function (err) {


### PR DESCRIPTION
This is a small addition which attaches a jscs object to the stream's file object. I read issue #51, was looking for exactly the same thing, and it was easy enough to tack on without side effects. 

I didn't see #39 or #41 until after I pushed this. It's slightly different than the implementation @butterflyhug proposed, but more in line with what gulp-jshint is doing. 