### PR TITLE
Travis-CI timing out on code style check

### DIFF
--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var gutil = require('gulp-util');
 var jscs = require('./');
 
 it('should check code style of JS files', function (cb) {
+	this.timeout(5000);
 	var stream = jscs();
 
 	stream.on('error', function (err) {


### PR DESCRIPTION
Travis-CI started timing out after two seconds. This change adds a test-specific 5 second timeout to the first check so the test passes again. 

#57 was rebased on top of this, its Travis-CI checks should now be passing. 

I noticed the problem with #57, but confirmed the issue with a clean fork of the latest public release. 