### PR TITLE
Add gulp-jshint-like reporters, fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var loadConfigFile = require('jscs/lib/cli-config');
 var assign = require('object-assign');
 var tildify = require('tildify');
 
-var plugin = module.exports = function (options) {
+module.exports = function (options) {
 	options = options || '.jscsrc';
 
 	if (typeof options === 'string') {
@@ -88,4 +88,4 @@ var plugin = module.exports = function (options) {
 	});
 };
 
-plugin.reporter = require('./reporters');
+module.exports.reporter = require('./reporters');

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');
 var assign = require('object-assign');
 var tildify = require('tildify');
+var reporters = require('./reporters');
 
-module.exports = function (options) {
+module.exports = exports = function (options) {
 	options = options || '.jscsrc';
 
 	if (typeof options === 'string') {
@@ -16,7 +17,6 @@ module.exports = function (options) {
 
 	options = assign({esnext: false}, options);
 
-	var out = [];
 	var checker = new Checker({esnext: !!options.esnext});
 
 	checker.registerDefaultRules();
@@ -83,24 +83,16 @@ module.exports = function (options) {
 			if (errorList.length > 0) {
 				file.jscs.success = false;
 				file.jscs.errorCount = errorList.length;
-				file.jscs.errors = errorList;
+				file.jscs.errors = errors;
 			}
-
-			errorList.forEach(function (err) {
-				out.push(errors.explainError(err, true));
-			});
 		} catch (err) {
-			out.push(err.stack.replace('null:', file.relative + ':'));
+			console.error(err.stack.replace('null:', file.relative + ':'));
 		}
 
 		cb(null, file);
-	}, function (cb) {
-		if (out.length > 0) {
-			this.emit('error', new gutil.PluginError('gulp-jscs', out.join('\n\n'), {
-				showStack: false
-			}));
-		}
-
-		cb();
 	});
 };
+
+exports.failReporter = reporters.fail;
+exports.loadReporter = reporters.loadReporter;
+exports.reporter = reporters.reporter;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');
 var assign = require('object-assign');
 var tildify = require('tildify');
-var reporters = require('./reporters');
 
 var plugin = module.exports = function (options) {
 	options = options || '.jscsrc';
@@ -89,4 +88,4 @@ var plugin = module.exports = function (options) {
 	});
 };
 
-plugin.reporter = reporter;
+plugin.reporter = require('./reporters');

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var assign = require('object-assign');
 var tildify = require('tildify');
 var reporters = require('./reporters');
 
-module.exports = exports = function (options) {
+var plugin = module.exports = function (options) {
 	options = options || '.jscsrc';
 
 	if (typeof options === 'string') {
@@ -93,6 +93,4 @@ module.exports = exports = function (options) {
 	});
 };
 
-exports.failReporter = reporters.fail;
-exports.loadReporter = reporters.loadReporter;
-exports.reporter = reporters.reporter;
+plugin.reporter = reporter;

--- a/index.js
+++ b/index.js
@@ -59,34 +59,30 @@ var plugin = module.exports = function (options) {
 			return;
 		}
 
-		try {
-			var fixResults;
-			var errors;
-			var contents = file.contents.toString();
+		var fixResults;
+		var errors;
+		var contents = file.contents.toString();
 
-			if (shouldFix) {
-				fixResults = checker.fixString(contents, file.relative);
-				errors = fixResults.errors;
-				file.contents = new Buffer(fixResults.output);
-			} else {
-				errors = checker.checkString(contents, file.relative);
-			}
+		if (shouldFix) {
+			fixResults = checker.fixString(contents, file.relative);
+			errors = fixResults.errors;
+			file.contents = new Buffer(fixResults.output);
+		} else {
+			errors = checker.checkString(contents, file.relative);
+		}
 
-			var errorList = errors.getErrorList();
+		var errorList = errors.getErrorList();
 
-			file.jscs = {
-				success: true,
-				errorCount: 0,
-				errors: []
-			};
+		file.jscs = {
+			success: true,
+			errorCount: 0,
+			errors: []
+		};
 
-			if (errorList.length > 0) {
-				file.jscs.success = false;
-				file.jscs.errorCount = errorList.length;
-				file.jscs.errors = errors;
-			}
-		} catch (err) {
-			console.error(err.stack.replace('null:', file.relative + ':'));
+		if (errorList.length > 0) {
+			file.jscs.success = false;
+			file.jscs.errorCount = errorList.length;
+			file.jscs.errors = errors;
 		}
 
 		cb(null, file);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "pretest": "jscs *.js",
+    "pretest": "jscs *.js reporters",
     "test": "mocha"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tildify": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "stream-assert": "^2.0.2"
   }
 }

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -5,10 +5,10 @@ var through = require('through2');
 module.exports = function (opts) {
 	opts = opts || {};
 
-	// @type false|[]paths - paths to files that failed JSCS
+	// paths to files that failed JSCS
 	var fails = false;
 
-	// @type false|[]files - files that need to be passed downstream on flush
+	// files that need to be passed downstream on flush
 	var buffer = opts.buffer !== false ? [] : false;
 
 	return through.obj(function (file, enc, cb) {

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -20,7 +20,7 @@ module.exports = function (opts) {
 		// buffer or pass downstream
 		(buffer || this).push(file);
 		cb();
-	}, function () {
+	}, function (cb) {
 		if (fails) {
 			this.emit('error', new PluginError('gulp-jscs', {
 				message: 'JSCS failed for: ' + fails.join(', '),
@@ -34,5 +34,7 @@ module.exports = function (opts) {
 				this.push(file);
 			}, this);
 		}
+
+		cb();
 	});
 };

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -2,14 +2,9 @@
 var PluginError = require('gulp-util').PluginError;
 var through = require('through2');
 
-module.exports = function (opts) {
-	opts = opts || {};
-
+module.exports = function () {
 	// paths to files that failed JSCS
 	var fails = false;
-
-	// files that need to be passed downstream on flush
-	var buffer = opts.buffer !== false ? [] : false;
 
 	return through.obj(function (file, enc, cb) {
 		// check for failure
@@ -17,8 +12,7 @@ module.exports = function (opts) {
 			(fails = fails || []).push(file.path);
 		}
 
-		// buffer or pass downstream
-		(buffer || this).push(file);
+		this.push(file);
 		cb();
 	}, function (cb) {
 		if (fails) {
@@ -26,13 +20,6 @@ module.exports = function (opts) {
 				message: 'JSCS failed for: ' + fails.join(', '),
 				showStack: false
 			}));
-		}
-
-		if (buffer) {
-			// send the buffered files downstream
-			buffer.forEach(function (file) {
-				this.push(file);
-			}, this);
 		}
 
 		cb();

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -1,0 +1,38 @@
+'use strict';
+var PluginError = require('gulp-util').PluginError;
+var through = require('through2');
+
+module.exports = function (opts) {
+	opts = opts || {};
+
+	// @type false|[]paths - paths to files that failed JSCS
+	var fails = false;
+
+	// @type false|[]files - files that need to be passed downstream on flush
+	var buffer = opts.buffer !== false ? [] : false;
+
+	return through.obj(function (file, enc, cb) {
+		// check for failure
+		if (file.jscs && !file.jscs.success) {
+			(fails = fails || []).push(file.path);
+		}
+
+		// buffer or pass downstream
+		(buffer || this).push(file);
+		cb();
+	}, function () {
+		if (fails) {
+			this.emit('error', new PluginError('gulp-jscs', {
+				message: 'JSCS failed for: ' + fails.join(', '),
+				showStack: false
+			}));
+		}
+
+		if (buffer) {
+			// send the buffered files downstream
+			buffer.forEach(function (file) {
+				this.push(file);
+			}, this);
+		}
+	});
+};

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -2,20 +2,30 @@
 var PluginError = require('gulp-util').PluginError;
 var through = require('through2');
 
-module.exports = function () {
+module.exports = function (failImmediately) {
 	// paths to files that failed JSCS
 	var fails = false;
 
 	return through.obj(function (file, enc, cb) {
+		var error = null;
+
 		// check for failure
 		if (file.jscs && !file.jscs.success) {
-			(fails = fails || []).push(file.path);
+			if (failImmediately) {
+				error = new PluginError('gulp-jscs', {
+					message: 'JSCS failed for: ' + file.path,
+					showStack: false
+				});
+			} else {
+				(fails = fails || []).push(file.path);
+			}
 		}
 
-		this.push(file);
-		cb();
+		cb(error, file);
 	}, function (cb) {
-		if (fails) {
+		if (!failImmediately && fails) {
+			// calling `cb(err)` would not emit the `end` event,
+			// so emit the error explicitly and call `cb()` afterwards.
 			this.emit('error', new PluginError('gulp-jscs', {
 				message: 'JSCS failed for: ' + fails.join(', '),
 				showStack: false

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -15,8 +15,7 @@ exports.loadReporter = function (reporter) {
 	// load JSCS built-in or full-path or module reporters
 	if (typeof reporter === 'string' || !reporter) {
 		try {
-			var rpt = getReporter(reporter);
-			return rpt.writer || rpt;
+			return getReporter(reporter).writer;
 		} catch (err) {}
 	}
 };

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -1,0 +1,45 @@
+'use strict';
+var getReporter = require('jscs/lib/cli-config').getReporter;
+var PluginError = require('gulp-util').PluginError;
+var through = require('through2');
+
+exports.failReporter = require('./fail');
+
+exports.loadReporter = function (reporter) {
+	// we want the function
+	if (typeof reporter === 'function') return reporter;
+
+	// object reporters
+	if (typeof reporter === 'object' && typeof reporter.reporter === 'function') return reporter.reporter;
+
+	// load JSCS built-in or full-path or module reporters
+	if (typeof reporter === 'string' || !reporter) {
+		try {
+			var rpt = getReporter(reporter);
+			return rpt.writer || rpt;
+		} catch (err) {}
+	}
+};
+
+exports.reporter = function (reporter, reporterCfg) {
+	reporterCfg = reporterCfg || {};
+
+	if (reporter === 'fail') {
+		return exports.failReporter(reporterCfg);
+	}
+
+	var rpt = exports.loadReporter(reporter);
+
+	if (typeof rpt !== 'function') {
+		throw new PluginError('gulp-jscs', 'Invalid reporter');
+	}
+
+	// return stream that reports stuff
+	return through.obj(function (file, enc, cb) {
+		if (file.jscs && !file.jscs.success) {
+			rpt([file.jscs.errors]);
+		}
+
+		cb(null, file);
+	});
+};

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -4,11 +4,9 @@ var through = require('through2');
 var loadReporter = require('./loadReporter');
 var failReporter = require('./fail');
 
-module.exports = function (reporter, reporterCfg) {
-	reporterCfg = reporterCfg || {};
-
+module.exports = function (reporter) {
 	if (reporter === 'fail') {
-		return failReporter(reporterCfg);
+		return failReporter();
 	}
 
 	var rpt = loadReporter(reporter);

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -1,33 +1,17 @@
 'use strict';
-var getReporter = require('jscs/lib/cli-config').getReporter;
 var PluginError = require('gulp-util').PluginError;
 var through = require('through2');
+var loadReporter = require('./loadReporter');
+var failReporter = require('./fail');
 
-exports.failReporter = require('./fail');
-
-exports.loadReporter = function (reporter) {
-	// we want the function
-	if (typeof reporter === 'function') return reporter;
-
-	// object reporters
-	if (typeof reporter === 'object' && typeof reporter.reporter === 'function') return reporter.reporter;
-
-	// load JSCS built-in or full-path or module reporters
-	if (typeof reporter === 'string' || !reporter) {
-		try {
-			return getReporter(reporter).writer;
-		} catch (err) {}
-	}
-};
-
-exports.reporter = function (reporter, reporterCfg) {
+module.exports = function (reporter, reporterCfg) {
 	reporterCfg = reporterCfg || {};
 
 	if (reporter === 'fail') {
-		return exports.failReporter(reporterCfg);
+		return failReporter(reporterCfg);
 	}
 
-	var rpt = exports.loadReporter(reporter);
+	var rpt = loadReporter(reporter);
 
 	if (typeof rpt !== 'function') {
 		throw new PluginError('gulp-jscs', 'Invalid reporter');

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -5,8 +5,8 @@ var loadReporter = require('./loadReporter');
 var failReporter = require('./fail');
 
 module.exports = function (reporter) {
-	if (reporter === 'fail') {
-		return failReporter();
+	if (reporter === 'fail' || reporter === 'failImmediately') {
+		return failReporter(reporter === 'failImmediately');
 	}
 
 	var rpt = loadReporter(reporter);

--- a/reporters/loadReporter.js
+++ b/reporters/loadReporter.js
@@ -1,0 +1,16 @@
+'use strict';
+var getReporter = require('jscs/lib/cli-config').getReporter;
+
+module.exports = function (reporter) {
+	// we want the function
+	if (typeof reporter === 'function') return reporter;
+
+	// load JSCS built-in or full-path or module reporters
+	if (typeof reporter === 'string' || !reporter) {
+		var rpt = getReporter(reporter).writer;
+		if (rpt) return rpt;
+		try {
+			return require(reporter);
+		} catch (err) {}
+	}
+};

--- a/reporters/loadReporter.js
+++ b/reporters/loadReporter.js
@@ -5,12 +5,6 @@ module.exports = function (reporter) {
 	// we want the function
 	if (typeof reporter === 'function') return reporter;
 
-	// load JSCS built-in or full-path or module reporters
-	if (typeof reporter === 'string' || !reporter) {
-		var rpt = getReporter(reporter).writer;
-		if (rpt) return rpt;
-		try {
-			return require(reporter);
-		} catch (err) {}
-	}
+	// load JSCS built-in or absolute path or module reporters
+	return getReporter(reporter).writer;
 };

--- a/test.js
+++ b/test.js
@@ -69,7 +69,7 @@ it('should pass valid files', function (cb) {
 	var stream = jscs();
 
 	stream.pipe(jscs.reporter()).pipe(jscs.reporter('fail')).on('error', function (err) {
-		assert(false);
+		assert(false, err);
 	}).on('end', cb).resume();
 
 	stream.write(new gutil.File({

--- a/test.js
+++ b/test.js
@@ -25,11 +25,11 @@ it('should check code style of JS files', function (cb) {
 	var stream = jscs();
 
 	stream
-		.pipe(streamAssert.first(function(file) {
+		.pipe(streamAssert.first(function (file) {
 			var errors = file.jscs.errors;
 			assert(/Multiple var declaration/.test(errors.explainError(errors.getErrorList()[0], false)));
 		}))
-		.pipe(streamAssert.second(function(file) {
+		.pipe(streamAssert.second(function (file) {
 			var errors = file.jscs.errors;
 			assert(/Illegal space before/.test(errors.explainError(errors.getErrorList()[1], false)));
 		}))
@@ -54,7 +54,7 @@ it('should check code style of JS files using a preset', function (cb) {
 	var stream = jscs({preset: 'google'});
 
 	stream
-		.pipe(streamAssert.first(function(file) {
+		.pipe(streamAssert.first(function (file) {
 			var errors = file.jscs.errors;
 			assert(/Missing line feed at file end/.test(errors.explainError(errors.getErrorList()[1], false)));
 		}))
@@ -107,7 +107,7 @@ it('should accept both esnext and configPath options', function(cb) {
 	});
 
 	stream
-		.pipe(streamAssert.first(function(file) {
+		.pipe(streamAssert.first(function (file) {
 			var errors = file.jscs.errors;
 			var errorList = errors.getErrorList();
 			assert(errorList.length === 1 && /Multiple var declaration/.test(errors.explainError(errorList[0], false)));

--- a/test.js
+++ b/test.js
@@ -179,7 +179,7 @@ describe('Reporter', function () {
 		stream.end();
 	});
 
-	it('`.reporter()` should accept a built-in JSCS reporter name', function (cb) {
+	it('`.reporter()` called with a non-function argument should delegate reporter loading to JSCS', function (cb) {
 		stubStdout();
 		var stream = jscs();
 

--- a/test.js
+++ b/test.js
@@ -179,7 +179,7 @@ describe('Reporter', function () {
 		stream.end();
 	});
 
-	it('should accept a built-in JSCS reporter name', function (cb) {
+	it('`.reporter()` should accept a built-in JSCS reporter name', function (cb) {
 		stubStdout();
 		var stream = jscs();
 
@@ -188,6 +188,25 @@ describe('Reporter', function () {
 			teardown();
 			cb();
 		}).resume();
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/fixture.js',
+			contents: new Buffer('var x = 1,y = 2;')
+		}));
+
+		stream.end();
+	});
+
+	it('`.reporter()` should accept a function', function (cb) {
+		function reporterFn(errors) {
+			assert(/Multiple var declaration/.test(errors[0].explainError(errors[0].getErrorList()[0], false)));
+			cb();
+		}
+
+		var stream = jscs();
+
+		stream.pipe(jscs.reporter(reporterFn)).resume();
 
 		stream.write(new gutil.File({
 			base: __dirname,
@@ -261,25 +280,6 @@ describe('Reporter', function () {
 			base: __dirname,
 			path: __dirname + '/passing.js',
 			contents: new Buffer('var x = 1; var y = 2;')
-		}));
-
-		stream.end();
-	});
-
-	it('should accept a function', function (cb) {
-		function reporterFn(errors) {
-			assert(/Multiple var declaration/.test(errors[0].explainError(errors[0].getErrorList()[0], false)));
-			cb();
-		}
-
-		var stream = jscs();
-
-		stream.pipe(jscs.reporter(reporterFn)).resume();
-
-		stream.write(new gutil.File({
-			base: __dirname,
-			path: __dirname + '/fixture.js',
-			contents: new Buffer('var x = 1,y = 2;')
 		}));
 
 		stream.end();

--- a/test.js
+++ b/test.js
@@ -68,7 +68,7 @@ it('should check code style of JS files using a preset', function (cb) {
 it('should pass valid files', function (cb) {
 	var stream = jscs();
 
-	stream.pipe(jscs.reporter()).pipe(jscs.reporter('fail')).on('error', function (err) {
+	stream.pipe(jscs.reporter('fail')).on('error', function (err) {
 		assert(false, err);
 	}).on('end', cb).resume();
 
@@ -83,7 +83,7 @@ it('should pass valid files', function (cb) {
 it('should respect "excludeFiles" from config', function (cb) {
 	var stream = jscs();
 
-	stream.pipe(jscs.reporter()).pipe(jscs.reporter('fail')).on('error', function (err) {
+	stream.pipe(jscs.reporter('fail')).on('error', function (err) {
 		assert(false, err);
 	}).on('end', cb).resume();
 
@@ -152,4 +152,79 @@ it('should not mutate the options object passed as argument', function () {
 	var options = {esnext: true};
 	jscs(options);
 	assert.equal(options.esnext, true);
+});
+
+describe('Reporter', function () {
+	it('`.reporter()` called with no arguments should use the default reporter', function (cb) {
+		stubStdout();
+		var stream = jscs();
+
+		stream.pipe(jscs.reporter()).on('end', function (err) {
+			assert(/Multiple var declaration[^]*---\^/.test(stdoutStub));
+			teardown();
+			cb();
+		}).resume();
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/fixture.js',
+			contents: new Buffer('var x = 1,y = 2;')
+		}));
+
+		stream.end();
+	});
+
+	it('should accept a built-in JSCS reporter name', function (cb) {
+		stubStdout();
+		var stream = jscs();
+
+		stream.pipe(jscs.reporter('inlinesingle')).on('end', function (err) {
+			assert(/line 1, col 0, Multiple var declaration/.test(stdoutStub));
+			teardown();
+			cb();
+		}).resume();
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/fixture.js',
+			contents: new Buffer('var x = 1,y = 2;')
+		}));
+
+		stream.end();
+	});
+
+	it('`fail` reporter should throw an error', function (cb) {
+		var stream = jscs();
+
+		stream.pipe(jscs.reporter('fail')).on('error', function (/* some args here so can't pass cb directly */) {
+			cb();
+		}).resume();
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/fixture.js',
+			contents: new Buffer('var x = 1,y = 2;')
+		}));
+
+		stream.end();
+	});
+
+	it('should accept a function', function (cb) {
+		function reporterFn(errors) {
+			assert(/Multiple var declaration/.test(errors[0].explainError(errors[0].getErrorList()[0], false)));
+			cb();
+		}
+
+		var stream = jscs();
+
+		stream.pipe(jscs.reporter(reporterFn)).resume();
+
+		stream.write(new gutil.File({
+			base: __dirname,
+			path: __dirname + '/fixture.js',
+			contents: new Buffer('var x = 1,y = 2;')
+		}));
+
+		stream.end();
+	});
 });


### PR DESCRIPTION
This is an early implementation, lacks docs and tests but seems to work for the basic use cases.

Basic usage:

```js
var gulp = require('gulp');
var jscs = require('gulp-jscs');

gulp.task('default', function () {
  return gulp.src('fix/*.js')
    .pipe(jscs())
    .pipe(jscs.reporter())
    .pipe(jscs.reporter('fail'))
    ;
});
```

Fixes #21 