### PR TITLE
search for config file when no options passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ var assign = require('object-assign');
 var tildify = require('tildify');
 
 module.exports = function (options) {
-	options = options || '.jscsrc';
-
 	if (typeof options === 'string') {
 		options = {configPath: options};
 	}
@@ -39,8 +37,10 @@ module.exports = function (options) {
 			err.message = 'Unable to load JSCS config file at ' + tildify(path.resolve(configPath)) + '\n' + err.message;
 			throw err;
 		}
-	} else {
+	} else if (JSON.stringify(options) !== '{}') {
 		checker.configure(options);
+	} else {
+		checker.configure(loadConfigFile.load());
 	}
 
 	return through.obj(function (file, enc, cb) {

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,9 @@ Type: `object`
 
 See the `jscs` [options](http://jscs.info/overview.html#options).
 
-Alternatively you can set the `configPath` *(default: `'.jscsrc'`)* option to the path of a [.jscsrc](http://jscs.info/rules.html) file.
+Alternatively you can set the `configPath` *(default: `'.jscsrc'`)* option to the path of a [.jscsrc](http://jscs.info/rules.html) file, or if no
+argument is passed the first `.jscsrc` file found will be used, starting with current working directory then searching ancestor directories until
+the system root is reached.
 
 Set `esnext: true` if you want your code to be parsed as ES6 using the harmony
 version of the esprima parser.


### PR DESCRIPTION
http://jscs.info/overview.html#-config- says

> If there is no --config option specified, jscs it will consequentially search for jscsConfig option in package.json file then for .jscsrc (which is a just JSON with comments) and .jscs.json files in the current working directory then in nearest ancestor until it hits the system root.

I have a `.jscsrc` file in the parent directory but I get an error if I don't specify the location explicitly eg

    gulp.task('default', function () {
        return gulp.src('src/app.js')
            .pipe(jscs({configPath: '../.jscsrc'});
        });

This change implements the 'search for config file' behaviour when no arguments are passed to `jscs()`.