### PR TITLE
Add error handling when config file missing

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,7 @@ module.exports = function (options) {
 		try {
 			checker.configure(loadConfigFile.load(configPath));
 		} catch (error) {
-			throw new Error(
-				'Unable to load JSCS config file at ' + path.join(process.cwd(), configPath);
-			);
+			throw new Error('Unable to load JSCS config file at ' + path.join(process.cwd(), configPath));
 		}
 	} else {
 		checker.configure(options);

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (options) {
 	delete options.configPath;
 
 	if (configPath) {
-		if (Object.keys(options).length) {
+		if (typeof options === 'object' && Object.keys(options).length) {
 			throw new Error('configPath option is not compatible with code style options');
 		}
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,13 @@ module.exports = function (options) {
 			throw new Error('configPath option is not compatible with code style options');
 		}
 
-		checker.configure(loadConfigFile.load(configPath));
+		try {
+			checker.configure(loadConfigFile.load(configPath));
+		} catch (error) {
+			var fullPath = process.cwd().concat('/').concat(configPath),
+				errorMessage = 'Unable to load JSCS config file at ' + fullPath;
+			throw new Error(errorMessage);
+		}
 	} else {
 		checker.configure(options);
 	}

--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ module.exports = function (options) {
 		try {
 			checker.configure(loadConfigFile.load(configPath));
 		} catch (error) {
-			var fullPath = process.cwd().concat('/').concat(configPath),
-				errorMessage = 'Unable to load JSCS config file at ' + fullPath;
-			throw new Error(errorMessage);
+			throw new Error(
+				'Unable to load JSCS config file at ' + 
+				process.cwd().concat('/').concat(configPath)
+			);
 		}
 	} else {
 		checker.configure(options);

--- a/index.js
+++ b/index.js
@@ -32,8 +32,7 @@ module.exports = function (options) {
 			checker.configure(loadConfigFile.load(configPath));
 		} catch (error) {
 			throw new Error(
-				'Unable to load JSCS config file at ' + 
-				process.cwd().concat('/').concat(configPath)
+				'Unable to load JSCS config file at ' + path.join(process.cwd(), configPath);
 			);
 		}
 	} else {


### PR DESCRIPTION
When a file is missing, there was no error handling and the console would log an error about `Object.keys()`, which is not enough to figure out that a file was missing.

This PR adds verbose error handling.