### PR TITLE
Add path object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var gutil = require('gulp-util');
+var path = require('path');
 var through = require('through2');
 var Checker = require('jscs');
 var loadConfigFile = require('jscs/lib/cli-config');


### PR DESCRIPTION
Add require('path') to avoid ReferenceError: path is not defined in line 34-35