### PR TITLE
Support fix option

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,17 +62,12 @@ module.exports = function (options) {
 		try {
 			var fixResults;
 			var errors;
-			var changed = false;
 			var contents = file.contents.toString();
 
 			if (shouldFix) {
 				fixResults = checker.fixString(contents, file.relative);
 				errors = fixResults.errors;
-				changed = contents !== fixResults.output;
-
-				if (changed) {
-					file.contents = new Buffer(fixResults.output);
-				}
+				file.contents = new Buffer(fixResults.output);
 			} else {
 				errors = checker.checkString(contents, file.relative);
 			}
@@ -80,7 +75,6 @@ module.exports = function (options) {
 			var errorList = errors.getErrorList();
 
 			file.jscs = {
-				fixed: changed,
 				success: true,
 				errorCount: 0,
 				errors: []

--- a/readme.md
+++ b/readme.md
@@ -43,26 +43,6 @@ gulp.task('default', function () {
 });
 ```
 
-By default, this will cause all your files to be rewritten each time this task runs. If you'd like to only write fixed files, use `gulp-filter`:
-
-```js
-var gulp = require('gulp');
-var jscs = require('gulp-jscs');
-var filter = require('gulp-filter');
-
-gulp.task('default', function () {
-	var fixedFilter = filter(function (file) {
-		return file.jscs && file.jscs.fixed === true;
-	});
-	return gulp.src('src/**/*.js')
-		.pipe(jscs({
-			fix: true
-		}))
-		.pipe(fixedFilter)
-		.pipe(gulp.dest('src'));
-});
-```
-
 ## Results
 
 A `jscs` object will be attached to the file object which can be used for custom error reporting. An example with one error might look like this:
@@ -70,7 +50,6 @@ A `jscs` object will be attached to the file object which can be used for custom
 ```js
 {
 	success: false,  // or true if no errors
-	fixed: false,    // or true if fix option is on and file was changed
 	errorCount: 1,   // number of errors in the errors array
 	errors: [{       // an array of jscs error objects
 		filename: 'index.js',  // basename of the file

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ $ npm install --save-dev gulp-jscs
 
 ## Usage
 
+### Reporting Only
+
 ```js
 var gulp = require('gulp');
 var jscs = require('gulp-jscs');
@@ -26,6 +28,40 @@ gulp.task('default', function () {
 });
 ```
 
+### Fixing and Reporting
+
+```js
+var gulp = require('gulp');
+var jscs = require('gulp-jscs');
+
+gulp.task('default', function () {
+	return gulp.src('src/app.js')
+		.pipe(jscs({
+			fix: true
+		}))
+		.pipe(gulp.dest('src'));
+});
+```
+
+By default, this will cause all your files to be rewritten each time this task runs. If you'd like to only write fixed files, use `gulp-filter`:
+
+```js
+var gulp = require('gulp');
+var jscs = require('gulp-jscs');
+var filter = require('gulp-filter');
+
+gulp.task('default', function () {
+	var fixedFilter = filter(function (file) {
+		return file.jscs && file.jscs.fixed === true;
+	});
+	return gulp.src('src/**/*.js')
+		.pipe(jscs({
+			fix: true
+		}))
+		.pipe(fixedFilter)
+		.pipe(gulp.dest('src'));
+});
+```
 
 ## Results
 
@@ -34,6 +70,7 @@ A `jscs` object will be attached to the file object which can be used for custom
 ```js
 {
 	success: false,  // or true if no errors
+	fixed: false,    // or true if fix option is on and file was changed
 	errorCount: 1,   // number of errors in the errors array
 	errors: [{       // an array of jscs error objects
 		filename: 'index.js',  // basename of the file
@@ -60,6 +97,8 @@ Alternatively you can set the `configPath` *(default: `'.jscsrc'`)* option to th
 
 Set `esnext: true` if you want your code to be parsed as ES6 using the harmony
 version of the esprima parser.
+
+Set `fix: true` if you want jscs to attempt to auto-fix your files. Be sure to pipe to `gulp.dest` if you use this option.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -107,6 +107,29 @@ it('should accept both esnext and configPath options', function(cb) {
 	stream.end();
 });
 
+it('should accept the fix option', function (cb) {
+	var data = '';
+
+	var stream = jscs({
+		fix: true,
+		configPath: '.jscsrc'
+	});
+
+	stream.on('data', function (file) {
+		assert.equal(file.contents.toString(), 'var x = {a: 1, b: 2}');
+	});
+
+	stream.on('end', cb);
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: __dirname + '/fixture.js',
+		contents: new Buffer('var x = { a: 1, b: 2 }')
+	}));
+
+	stream.end();
+});
+
 it('should throw when passing both configPath and code style options', function () {
 	assert.throws(jscs.bind(null, {
 		configPath: '.jscsrc',


### PR DESCRIPTION
We are working on transitioning from esformatter to jscs for formatting now that it supports auto fixing. We took a stab at adding support in gulp-jscs to accept a `fix` option. We also added a test and updated the readme. Please let us know if it requires any tweaks or if you prefer a different approach.