### PR TITLE
Update JSCS to next major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.4",
-    "jscs": "^1.12.0",
+    "jscs": "^2.0.0",
     "object-assign": "^2.0.0",
     "through2": "^0.6.5",
     "tildify": "^1.0.0"


### PR DESCRIPTION
This should probably lead to ``gulp-jscs@2.0``, but I'll leave the version change commit to the maintainer(s).