### PR TITLE
Fixed issue when "autofix" doesn't fix all files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = function (opts) {
 	opts = opts || {};
 
 	var config;
-	var overrides = {};
 	var checker = new Checker();
 
 	try {
@@ -29,10 +28,8 @@ module.exports = function (opts) {
 
 	// run autofix over as many errors as possible
 	if (opts.fix) {
-		overrides.maxErrors = Infinity;
+		config.maxErrors = Infinity;
 	}
-
-	checker.getConfiguration().override(overrides);
 
 	checker.registerDefaultRules();
 	checker.configure(config);

--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ var loadConfigFile = require('jscs/lib/cli-config');
 module.exports = function (opts) {
 	opts = opts || {};
 
+	var config;
+	var overrides = {};
 	var checker = new Checker();
 
-	checker.registerDefaultRules();
-
 	try {
-		checker.configure(loadConfigFile.load(opts.configPath));
+		config = loadConfigFile.load(opts.configPath);
 	} catch (err) {
 		err.message = 'Unable to load JSCS config file';
 
@@ -26,6 +26,16 @@ module.exports = function (opts) {
 
 		throw err;
 	}
+
+	// run autofix over as many errors as possible
+	if (opts.fix) {
+		overrides.maxErrors = Infinity;
+	}
+
+	checker.getConfiguration().override(overrides);
+
+	checker.registerDefaultRules();
+	checker.configure(config);
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/test.js
+++ b/test.js
@@ -147,6 +147,43 @@ it('should accept the fix option', function (cb) {
 	stream.end();
 });
 
+it('should run autofix over as many errors as possible', function (done) {
+	var config = {
+		maxErrors: 1,
+		requireSpaceBeforeBinaryOperators: ['=']
+	};
+	var validJS = 'var foo =1;\nvar bar =2;';
+	var invalidJS = 'var foo=1;\nvar bar=2;';
+
+	var stream = jscs({
+		fix: true,
+		configPath: tempWrite.sync(JSON.stringify(config))
+	});
+
+	stream
+		.pipe(streamAssert.first(function (file) {
+			assert.equal(file.contents.toString(), validJS);
+		}))
+		.pipe(streamAssert.second(function (file) {
+			assert.equal(file.contents.toString(), validJS);
+		}))
+		.pipe(streamAssert.end(done));
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: path.join(__dirname, 'fixture.js'),
+		contents: new Buffer(invalidJS)
+	}));
+
+	stream.write(new gutil.File({
+		base: __dirname,
+		path: path.join(__dirname, 'fixture2.js'),
+		contents: new Buffer(invalidJS)
+	}));
+
+	stream.end();
+});
+
 it('should not mutate the options object passed as argument', function () {
 	var options = {foo: true};
 	jscs(options);


### PR DESCRIPTION
If you haven't setted "maxErrors" property in your config file, it JSCS uses defaults (50). So in case we run task with "fix" setted to "true" we could only fix 50 errors.

I fixed this problem by setting "Infinity" value in case of fix is setted to true.