### PR TITLE
Pass full path into Checker instead of relative

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,11 @@ module.exports = function (opts) {
 		var contents = file.contents.toString();
 
 		if (opts.fix) {
-			fixResults = checker.fixString(contents, file.relative);
+			fixResults = checker.fixString(contents, file.path);
 			errors = fixResults.errors;
 			file.contents = new Buffer(fixResults.output);
 		} else {
-			errors = checker.checkString(contents, file.relative);
+			errors = checker.checkString(contents, file.path);
 		}
 
 		var errorList = errors.getErrorList();


### PR DESCRIPTION
AFAICT this path is only valuable to the Checker as a piece of information to pass to a reporter, so it makes sense to me to give the Checker the full filepath and let reporters sort out whether they want to display a relative path or not.