### PR TITLE
Add link for `gulp-reporter`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,9 @@ gulp.task('default', () => {
 });
 ```
 
+### Third party reporter
+
+[gulp-reporter](https://github.com/gucong3000/gulp-reporter) used in team project, it fails only when error belongs to the current author of git.
 
 ## Results
 


### PR DESCRIPTION
[gulp-reporter](https://github.com/gucong3000/gulp-reporter) used in team project, it fails only when error belongs to the current author of git.
