### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 var path = require('path');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var tildify = require('tildify');
 var Checker = require('jscs');
@@ -41,7 +41,7 @@ module.exports = function (opts) {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-jscs', 'Streaming not supported'));
+			cb(new PluginError('gulp-jscs', 'Streaming not supported'));
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "checker"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.4",
     "jscs": "^3.0.4",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.0",
     "tildify": "^1.0.0"
   },
@@ -43,6 +43,7 @@
     "mocha": "*",
     "stream-assert": "^2.0.2",
     "temp-write": "^2.1.0",
+    "vinyl": "^2.1.0",
     "xo": "*"
   }
 }

--- a/reporters/fail.js
+++ b/reporters/fail.js
@@ -1,5 +1,5 @@
 'use strict';
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var through = require('through2');
 
 module.exports = function (failImmediately) {

--- a/reporters/index.js
+++ b/reporters/index.js
@@ -1,5 +1,5 @@
 'use strict';
-var PluginError = require('gulp-util').PluginError;
+var PluginError = require('plugin-error');
 var through = require('through2');
 var loadReporter = require('./load-reporter');
 var failReporter = require('./fail');

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 'use strict';
 var path = require('path');
 var assert = require('assert');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var streamAssert = require('stream-assert');
 var tempWrite = require('temp-write');
 var jscs = require('./');
@@ -38,13 +38,13 @@ it('should check code style of JS files', function (cb) {
 		}))
 		.pipe(streamAssert.end(cb));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer('var x = 1,y = 2;')
 	}));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture2.js'),
 		contents: new Buffer('var x = { a: 1 };')
@@ -65,7 +65,7 @@ it('should check code style of JS files using a preset', function (cb) {
 		}))
 		.pipe(streamAssert.end(cb));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer('var x = 1,y = 2;')
@@ -81,7 +81,7 @@ it('should pass valid files', function (cb) {
 		assert(false, err);
 	}).on('end', cb).resume();
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer('var x = 1; var y = 2;')
 	}));
@@ -96,7 +96,7 @@ it('should respect "excludeFiles" from config', function (cb) {
 		assert(false, err);
 	}).on('end', cb).resume();
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'excluded.js'),
 		contents: new Buffer('var x = { a: 1 };')
@@ -118,7 +118,7 @@ it('should accept configPath options', function (cb) {
 		}))
 		.pipe(streamAssert.end(cb));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer('import x from \'x\'; var x = 1, y = 2;')
@@ -138,7 +138,7 @@ it('should accept the fix option', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer('var x = { a: 1, b: 2 }')
@@ -169,13 +169,13 @@ it('should run autofix over as many errors as possible', function (done) {
 		}))
 		.pipe(streamAssert.end(done));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture.js'),
 		contents: new Buffer(invalidJS)
 	}));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		base: __dirname,
 		path: path.join(__dirname, 'fixture2.js'),
 		contents: new Buffer(invalidJS)
@@ -201,7 +201,7 @@ describe('Reporter', function () {
 			cb();
 		}).resume();
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'fixture.js'),
 			contents: new Buffer('var x = 1,y = 2;')
@@ -220,7 +220,7 @@ describe('Reporter', function () {
 			cb();
 		}).resume();
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'fixture.js'),
 			contents: new Buffer('var x = 1,y = 2;')
@@ -239,7 +239,7 @@ describe('Reporter', function () {
 
 		stream.pipe(jscs.reporter(reporterFn)).resume();
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'fixture.js'),
 			contents: new Buffer('var x = 1,y = 2;')
@@ -276,13 +276,13 @@ describe('Reporter', function () {
 				cb();
 			}));
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'fixture.js'),
 			contents: new Buffer('var x = 1,y = 2;')
 		}));
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'passing.js'),
 			contents: new Buffer('var x = 1; var y = 2;')
@@ -305,13 +305,13 @@ describe('Reporter', function () {
 			}))
 			.pipe(streamAssert.end());
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'fixture.js'),
 			contents: new Buffer('var x = 1,y = 2;')
 		}));
 
-		stream.write(new gutil.File({
+		stream.write(new Vinyl({
 			base: __dirname,
 			path: path.join(__dirname, 'passing.js'),
 			contents: new Buffer('var x = 1; var y = 2;')


### PR DESCRIPTION
Closes jscs-dev/gulp-jscs#120